### PR TITLE
feat(lib): let storage handle TTL

### DIFF
--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -7,17 +7,7 @@ import "reflect-metadata";
 
 export const cacheEventEmitter = new EventEmitter();
 export const intervalTimerMap = new Map<string, boolean>();
-const timeouts: NodeJS.Timeout[] = [];
 const intervals: NodeJS.Timeout[] = [];
-
-export function clearAllTimeouts() {
-  for (const timeout of timeouts) {
-    clearTimeout(timeout);
-  }
-  for (const interval of intervals) {
-    clearInterval(interval);
-  }
-}
 
 type RootKey = `${string}${typeof ROOT_KEY_SUFFIX}`;
 const ROOT_KEY_SUFFIX = "__ROOT_KEY__" as const;
@@ -172,16 +162,7 @@ export const Cache =
 
           const result = await originalMethod.apply(this, args);
 
-          storage.set(cacheKey, result);
-
-          const timeout = setTimeout(async () => {
-            storage.delete(cacheKey);
-            if (await storage.has(rootKey)) {
-              deleteChildCacheKey(storage, cacheKey, rootKey);
-            }
-          }, ttl * 1000);
-
-          timeouts.push(timeout);
+          storage.set(cacheKey, result, ttl);
 
           return result;
         };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -18,6 +18,7 @@ export type CacheOptions<Kind extends CacheKind> = CacheOptionSchema[Kind] & {
 export interface ICacheStorage {
   get(key: string): any;
   set(key: string, value: any): any;
+  set(key: string, value: any, ttl?: number): any;
   delete(key: string): boolean | Promise<boolean>;
   has(key: string): boolean | Promise<boolean>;
 }


### PR DESCRIPTION
## Description

We propose that the storage should be the entity to handle TTL, provides flexibility in distributed systems were external storages are prominent (like Redis) and if the developer is using a memory storage, they can handle their own timeouts, we propose this change so that logic isn't abstracted away.

## Notes

* Tests were not updated to match the change, but it seems that the external storage in `./tests` already has the business logic to handle that.
* This is a breaking change.