### PR TITLE
Fix peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,8 @@
         "@nestjs/common": ">=8",
         "@nestjs/core": ">=8",
         "cache-manager": "<=5",
-        "reflect-metadata": "^0.1.12",
-        "rxjs": "^7.0.0"
+        "reflect-metadata": "^0.1.12 || ^0.2.0",
+        "rxjs": ">= 7.x"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "@nestjs/common": ">=8",
     "@nestjs/core": ">=8",
     "cache-manager": "<=5",
-    "reflect-metadata": "^0.1.12",
-    "rxjs": "^7.0.0"
+    "reflect-metadata": "^0.1.12 || ^0.2.0",
+    "rxjs": ">= 7.x"
   },
   "keywords": [
     "nest",


### PR DESCRIPTION
This library works with reflect-metadata versions 0.2.0, 0.2.1, and 0.2.2. It also works with versions of rxjs greater than 7, so I updated the peer dependencies to reflect that.