### PR TITLE
fix: remove unnecessary json parsing

### DIFF
--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -73,7 +73,7 @@ const getChildrenObject = async (storage, rootKey) => {
     throw new Error("Invalid root key");
   }
   try {
-    return JSON.parse(await storage.get(rootKey));
+    return await storage.get(rootKey);
   } catch (e) {
     throw new Error("cannot parse children object");
   }

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -32,13 +32,13 @@ const setChildCacheKey = async (
   rootKey: RootKey
 ) => {
   if (!(await storage.has(rootKey))) {
-    storage.set(rootKey, JSON.stringify({ [cacheKey]: 1 }));
+    storage.set(rootKey, { [cacheKey]: 1 });
     return;
   }
   const children = await getChildrenObject(storage, rootKey);
   if (children[cacheKey]) return;
   children[cacheKey] = 1;
-  storage.set(rootKey, JSON.stringify(children));
+  storage.set(rootKey, children);
 };
 
 const deleteChildCacheKey = async (
@@ -49,7 +49,7 @@ const deleteChildCacheKey = async (
   if (await storage.has(rootKey)) {
     const children = await getChildrenObject(storage, rootKey);
     delete children[cacheKey];
-    storage.set(rootKey, JSON.stringify(children));
+    storage.set(rootKey, children);
   }
 };
 


### PR DESCRIPTION
Removed JSON functions since the user should handle those. This keeps it similar to other libraries that offer a storage interface. Note: this could be considered a breaking change.

Closes #39